### PR TITLE
Drain Filter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minivec"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["LeonineKing1199 <christian.mazakas@gmail.com>"]
 edition = "2018"
 license = "BSL-1.0"

--- a/src/impl.rs
+++ b/src/impl.rs
@@ -1,8 +1,10 @@
 pub mod drain;
+pub mod drain_filter;
 pub mod helpers;
 pub mod into_iter;
 pub mod splice;
 
 pub use drain::Drain;
+pub use drain_filter::DrainFilter;
 pub use into_iter::IntoIter;
 pub use splice::Splice;

--- a/src/impl/drain_filter.rs
+++ b/src/impl/drain_filter.rs
@@ -4,4 +4,112 @@ where
 {
     vec: &'a mut crate::MiniVec<T>,
     pred: F,
+    old_len: usize,
+    new_len: usize,
+    pos: usize,
+    panicked: bool,
+}
+
+pub fn make_drain_filter_iterator<'a, T, F>(
+    vec: &'a mut crate::MiniVec<T>,
+    pred: F,
+) -> DrainFilter<'a, T, F>
+where
+    F: core::ops::FnMut(&mut T) -> bool,
+{
+    let old_len = vec.len();
+    DrainFilter {
+        vec,
+        pred,
+        old_len,
+        new_len: 0,
+        pos: 0,
+        panicked: false,
+    }
+}
+
+impl<T, F> core::iter::Iterator for DrainFilter<'_, T, F>
+where
+    F: core::ops::FnMut(&mut T) -> bool,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.pos < self.old_len {
+            let data = self.vec.data();
+            let mut val = unsafe { &mut *data.add(self.pos) };
+
+            self.panicked = true;
+
+            let pred_result = (self.pred)(&mut val);
+
+            self.panicked = false;
+
+            if pred_result {
+                self.pos += 1;
+                return Some(unsafe { core::ptr::read(val as *mut T) });
+            }
+
+            if self.pos > self.new_len {
+                let src = val as *mut T;
+                let dst = unsafe { data.add(self.new_len) };
+                unsafe { core::ptr::copy_nonoverlapping(src, dst, 1) };
+            }
+
+            self.pos += 1;
+            self.new_len += 1;
+        }
+
+        None
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(self.old_len - self.pos))
+    }
+}
+
+struct DropGuard<'a, 'b, T, F>
+where
+    F: core::ops::FnMut(&mut T) -> bool,
+{
+    drain: &'b mut DrainFilter<'a, T, F>,
+}
+
+impl<'a, 'b, T, F> Drop for DropGuard<'a, 'b, T, F>
+where
+    F: core::ops::FnMut(&mut T) -> bool,
+{
+    fn drop(&mut self) {
+        let num_remaining = self.drain.old_len - self.drain.pos;
+        let num_drained = self.drain.pos - self.drain.new_len;
+
+        if num_remaining > 0 && num_drained > 0 {
+            let data = self.drain.vec.as_mut_ptr();
+
+            let src = unsafe { data.add(self.drain.pos) };
+            let dst = unsafe { data.add(self.drain.new_len) };
+
+            unsafe { core::ptr::copy(src, dst, num_remaining) };
+        }
+
+        if self.drain.old_len == 0 {
+            return;
+        }
+
+        unsafe { self.drain.vec.set_len(self.drain.new_len + num_remaining) };
+    }
+}
+
+impl<T, F> Drop for DrainFilter<'_, T, F>
+where
+    F: core::ops::FnMut(&mut T) -> bool,
+{
+    fn drop(&mut self) {
+        let drop_guard = DropGuard { drain: self };
+        if drop_guard.drain.panicked {
+            return;
+        }
+
+        drop_guard.drain.for_each(drop);
+    }
 }

--- a/src/impl/drain_filter.rs
+++ b/src/impl/drain_filter.rs
@@ -1,0 +1,7 @@
+pub struct DrainFilter<'a, T, F>
+where
+    F: core::ops::FnMut(&mut T) -> bool,
+{
+    vec: &'a mut crate::MiniVec<T>,
+    pred: F,
+}

--- a/src/impl/into_iter.rs
+++ b/src/impl/into_iter.rs
@@ -16,7 +16,12 @@ impl<T> IntoIter<T> {
     #[must_use]
     pub fn new(w: crate::MiniVec<T>) -> Self {
         let v = w;
-        let pos = v.data();
+        let pos = if v.buf_.is_null() {
+            core::ptr::null_mut()
+        } else {
+            v.data()
+        };
+
         Self {
             v,
             pos,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1068,15 +1068,16 @@ impl<T> MiniVec<T> {
     /// ```
     ///
     pub fn spare_capacity_mut(&mut self) -> &mut [core::mem::MaybeUninit<T>] {
-        let count = self.len();
-        if count == 0 {
+        let capacity = self.capacity();
+        if capacity == 0 {
             return &mut [];
         }
 
-        let data = unsafe { self.data().add(count) as *mut core::mem::MaybeUninit<T> };
-        let len = self.capacity() - self.len();
+        let len = self.len();
+        let data = unsafe { self.data().add(len) as *mut core::mem::MaybeUninit<T> };
+        let spare_len = capacity - len;
 
-        unsafe { core::slice::from_raw_parts_mut(data, len) }
+        unsafe { core::slice::from_raw_parts_mut(data, spare_len) }
     }
 
     /// `splice` returns a `Splice` iterator. `Splice` is similar in spirit to `Drain` but instead

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,12 +84,10 @@ impl<T> MiniVec<T> {
     }
 
     fn data(&self) -> *mut T {
-        if self.buf_.is_null() {
-            core::ptr::null_mut()
-        } else {
-            let count = get_offset::<T>();
-            unsafe { self.buf_.add(count) as *mut T }
-        }
+        debug_assert!(!self.buf_.is_null());
+
+        let count = get_offset::<T>();
+        unsafe { self.buf_.add(count) as *mut T }
     }
 
     fn grow(&mut self, capacity: usize) {
@@ -1071,6 +1069,10 @@ impl<T> MiniVec<T> {
     ///
     pub fn spare_capacity_mut(&mut self) -> &mut [core::mem::MaybeUninit<T>] {
         let count = self.len();
+        if count == 0 {
+            return &mut [];
+        }
+
         let data = unsafe { self.data().add(count) as *mut core::mem::MaybeUninit<T> };
         let len = self.capacity() - self.len();
 

--- a/tests/vec.rs
+++ b/tests/vec.rs
@@ -894,21 +894,21 @@ fn overaligned_allocations() {
     }
 }
 
-// #[test]
-// fn drain_filter_empty() {
-//     let mut vec: Vec<i32> = vec![];
+#[test]
+fn drain_filter_empty() {
+    let mut vec: MiniVec<i32> = mini_vec![];
 
-//     {
-//         let mut iter = vec.drain_filter(|_| true);
-//         assert_eq!(iter.size_hint(), (0, Some(0)));
-//         assert_eq!(iter.next(), None);
-//         assert_eq!(iter.size_hint(), (0, Some(0)));
-//         assert_eq!(iter.next(), None);
-//         assert_eq!(iter.size_hint(), (0, Some(0)));
-//     }
-//     assert_eq!(vec.len(), 0);
-//     assert_eq!(vec, vec![]);
-// }
+    {
+        let mut iter = vec.drain_filter(|_| true);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+    }
+    assert_eq!(vec.len(), 0);
+    assert_eq!(vec, mini_vec![]);
+}
 
 // #[test]
 // fn drain_filter_zst() {
@@ -932,230 +932,250 @@ fn overaligned_allocations() {
 //     assert_eq!(vec, vec![]);
 // }
 
-// #[test]
-// fn drain_filter_false() {
-//     let mut vec = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+#[test]
+fn drain_filter_false() {
+    let mut vec = mini_vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
-//     let initial_len = vec.len();
-//     let mut count = 0;
-//     {
-//         let mut iter = vec.drain_filter(|_| false);
-//         assert_eq!(iter.size_hint(), (0, Some(initial_len)));
-//         for _ in iter.by_ref() {
-//             count += 1;
-//         }
-//         assert_eq!(iter.size_hint(), (0, Some(0)));
-//         assert_eq!(iter.next(), None);
-//         assert_eq!(iter.size_hint(), (0, Some(0)));
-//     }
+    let initial_len = vec.len();
+    let mut count = 0;
+    {
+        let mut iter = vec.drain_filter(|_| false);
+        assert_eq!(iter.size_hint(), (0, Some(initial_len)));
+        for _ in iter.by_ref() {
+            count += 1;
+        }
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+    }
 
-//     assert_eq!(count, 0);
-//     assert_eq!(vec.len(), initial_len);
-//     assert_eq!(vec, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-// }
+    assert_eq!(count, 0);
+    assert_eq!(vec.len(), initial_len);
+    assert_eq!(vec, mini_vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+}
 
-// #[test]
-// fn drain_filter_true() {
-//     let mut vec = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+#[test]
+fn drain_filter_true() {
+    let mut vec = mini_vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
-//     let initial_len = vec.len();
-//     let mut count = 0;
-//     {
-//         let mut iter = vec.drain_filter(|_| true);
-//         assert_eq!(iter.size_hint(), (0, Some(initial_len)));
-//         while let Some(_) = iter.next() {
-//             count += 1;
-//             assert_eq!(iter.size_hint(), (0, Some(initial_len - count)));
-//         }
-//         assert_eq!(iter.size_hint(), (0, Some(0)));
-//         assert_eq!(iter.next(), None);
-//         assert_eq!(iter.size_hint(), (0, Some(0)));
-//     }
+    let initial_len = vec.len();
+    let mut count = 0;
+    {
+        let mut iter = vec.drain_filter(|_| true);
+        assert_eq!(iter.size_hint(), (0, Some(initial_len)));
+        while let Some(_) = iter.next() {
+            count += 1;
+            assert_eq!(iter.size_hint(), (0, Some(initial_len - count)));
+        }
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+    }
 
-//     assert_eq!(count, initial_len);
-//     assert_eq!(vec.len(), 0);
-//     assert_eq!(vec, vec![]);
-// }
+    assert_eq!(count, initial_len);
+    assert_eq!(vec.len(), 0);
+    assert_eq!(vec, mini_vec![]);
+}
 
-// #[test]
-// fn drain_filter_complex() {
-//     {
-//         //                [+xxx++++++xxxxx++++x+x++]
-//         let mut vec = vec![
-//             1, 2, 4, 6, 7, 9, 11, 13, 15, 17, 18, 20, 22, 24, 26, 27, 29, 31, 33, 34, 35, 36, 37,
-//             39,
-//         ];
+#[test]
+fn drain_filter_complex() {
+    {
+        //                [+xxx++++++xxxxx++++x+x++]
+        let mut vec = mini_vec![
+            1, 2, 4, 6, 7, 9, 11, 13, 15, 17, 18, 20, 22, 24, 26, 27, 29, 31, 33, 34, 35, 36, 37,
+            39,
+        ];
 
-//         let removed = vec.drain_filter(|x| *x % 2 == 0).collect::<Vec<_>>();
-//         assert_eq!(removed.len(), 10);
-//         assert_eq!(removed, vec![2, 4, 6, 18, 20, 22, 24, 26, 34, 36]);
+        let removed = vec.drain_filter(|x| *x % 2 == 0).collect::<MiniVec<_>>();
+        assert_eq!(removed.len(), 10);
+        assert_eq!(removed, vec![2, 4, 6, 18, 20, 22, 24, 26, 34, 36]);
 
-//         assert_eq!(vec.len(), 14);
-//         assert_eq!(vec, vec![1, 7, 9, 11, 13, 15, 17, 27, 29, 31, 33, 35, 37, 39]);
-//     }
+        assert_eq!(vec.len(), 14);
+        assert_eq!(
+            vec,
+            vec![1, 7, 9, 11, 13, 15, 17, 27, 29, 31, 33, 35, 37, 39]
+        );
+    }
 
-//     {
-//         //                [xxx++++++xxxxx++++x+x++]
-//         let mut vec = vec![
-//             2, 4, 6, 7, 9, 11, 13, 15, 17, 18, 20, 22, 24, 26, 27, 29, 31, 33, 34, 35, 36, 37, 39,
-//         ];
+    {
+        //                [xxx++++++xxxxx++++x+x++]
+        let mut vec = mini_vec![
+            2, 4, 6, 7, 9, 11, 13, 15, 17, 18, 20, 22, 24, 26, 27, 29, 31, 33, 34, 35, 36, 37, 39,
+        ];
 
-//         let removed = vec.drain_filter(|x| *x % 2 == 0).collect::<Vec<_>>();
-//         assert_eq!(removed.len(), 10);
-//         assert_eq!(removed, vec![2, 4, 6, 18, 20, 22, 24, 26, 34, 36]);
+        let removed = vec.drain_filter(|x| *x % 2 == 0).collect::<MiniVec<_>>();
+        assert_eq!(removed.len(), 10);
+        assert_eq!(removed, vec![2, 4, 6, 18, 20, 22, 24, 26, 34, 36]);
 
-//         assert_eq!(vec.len(), 13);
-//         assert_eq!(vec, vec![7, 9, 11, 13, 15, 17, 27, 29, 31, 33, 35, 37, 39]);
-//     }
+        assert_eq!(vec.len(), 13);
+        assert_eq!(vec, vec![7, 9, 11, 13, 15, 17, 27, 29, 31, 33, 35, 37, 39]);
+    }
 
-//     {
-//         //                [xxx++++++xxxxx++++x+x]
-//         let mut vec =
-//             vec![2, 4, 6, 7, 9, 11, 13, 15, 17, 18, 20, 22, 24, 26, 27, 29, 31, 33, 34, 35, 36];
+    {
+        //                [xxx++++++xxxxx++++x+x]
+        let mut vec = mini_vec![
+            2, 4, 6, 7, 9, 11, 13, 15, 17, 18, 20, 22, 24, 26, 27, 29, 31, 33, 34, 35, 36,
+        ];
 
-//         let removed = vec.drain_filter(|x| *x % 2 == 0).collect::<Vec<_>>();
-//         assert_eq!(removed.len(), 10);
-//         assert_eq!(removed, vec![2, 4, 6, 18, 20, 22, 24, 26, 34, 36]);
+        let removed = vec.drain_filter(|x| *x % 2 == 0).collect::<MiniVec<_>>();
+        assert_eq!(removed.len(), 10);
+        assert_eq!(removed, vec![2, 4, 6, 18, 20, 22, 24, 26, 34, 36]);
 
-//         assert_eq!(vec.len(), 11);
-//         assert_eq!(vec, vec![7, 9, 11, 13, 15, 17, 27, 29, 31, 33, 35]);
-//     }
+        assert_eq!(vec.len(), 11);
+        assert_eq!(vec, vec![7, 9, 11, 13, 15, 17, 27, 29, 31, 33, 35]);
+    }
 
-//     {
-//         //                [xxxxxxxxxx+++++++++++]
-//         let mut vec = vec![2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
+    {
+        //                [xxxxxxxxxx+++++++++++]
+        let mut vec =
+            mini_vec![2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19,];
 
-//         let removed = vec.drain_filter(|x| *x % 2 == 0).collect::<Vec<_>>();
-//         assert_eq!(removed.len(), 10);
-//         assert_eq!(removed, vec![2, 4, 6, 8, 10, 12, 14, 16, 18, 20]);
+        let removed = vec.drain_filter(|x| *x % 2 == 0).collect::<MiniVec<_>>();
+        assert_eq!(removed.len(), 10);
+        assert_eq!(removed, vec![2, 4, 6, 8, 10, 12, 14, 16, 18, 20]);
 
-//         assert_eq!(vec.len(), 10);
-//         assert_eq!(vec, vec![1, 3, 5, 7, 9, 11, 13, 15, 17, 19]);
-//     }
+        assert_eq!(vec.len(), 10);
+        assert_eq!(vec, vec![1, 3, 5, 7, 9, 11, 13, 15, 17, 19]);
+    }
 
-//     {
-//         //                [+++++++++++xxxxxxxxxx]
-//         let mut vec = vec![1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
+    {
+        //                [+++++++++++xxxxxxxxxx]
+        let mut vec =
+            mini_vec![1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20,];
 
-//         let removed = vec.drain_filter(|x| *x % 2 == 0).collect::<Vec<_>>();
-//         assert_eq!(removed.len(), 10);
-//         assert_eq!(removed, vec![2, 4, 6, 8, 10, 12, 14, 16, 18, 20]);
+        let removed = vec.drain_filter(|x| *x % 2 == 0).collect::<MiniVec<_>>();
+        assert_eq!(removed.len(), 10);
+        assert_eq!(removed, vec![2, 4, 6, 8, 10, 12, 14, 16, 18, 20]);
 
-//         assert_eq!(vec.len(), 10);
-//         assert_eq!(vec, vec![1, 3, 5, 7, 9, 11, 13, 15, 17, 19]);
-//     }
-// }
+        assert_eq!(vec.len(), 10);
+        assert_eq!(vec, vec![1, 3, 5, 7, 9, 11, 13, 15, 17, 19]);
+    }
+}
 
-// // FIXME: re-enable emscripten once it can unwind again
-// #[test]
-// #[cfg(not(target_os = "emscripten"))]
-// fn drain_filter_consumed_panic() {
-//     use std::rc::Rc;
-//     use std::sync::Mutex;
+// FIXME: re-enable emscripten once it can unwind again
+#[test]
+#[cfg(not(target_os = "emscripten"))]
+fn drain_filter_consumed_panic() {
+    use std::rc::Rc;
+    use std::sync::Mutex;
 
-//     struct Check {
-//         index: usize,
-//         drop_counts: Rc<Mutex<Vec<usize>>>,
-//     };
+    struct Check {
+        index: usize,
+        drop_counts: Rc<Mutex<MiniVec<usize>>>,
+    };
 
-//     impl Drop for Check {
-//         fn drop(&mut self) {
-//             self.drop_counts.lock().unwrap()[self.index] += 1;
-//             println!("drop: {}", self.index);
-//         }
-//     }
+    impl Drop for Check {
+        fn drop(&mut self) {
+            self.drop_counts.lock().unwrap()[self.index] += 1;
+            println!("drop: {}", self.index);
+        }
+    }
 
-//     let check_count = 10;
-//     let drop_counts = Rc::new(Mutex::new(vec![0_usize; check_count]));
-//     let mut data: Vec<Check> = (0..check_count)
-//         .map(|index| Check { index, drop_counts: Rc::clone(&drop_counts) })
-//         .collect();
+    let check_count = 10;
+    let drop_counts = Rc::new(Mutex::new(mini_vec![0_usize; check_count]));
+    let mut data: MiniVec<Check> = (0..check_count)
+        .map(|index| Check {
+            index,
+            drop_counts: Rc::clone(&drop_counts),
+        })
+        .collect();
 
-//     let _ = std::panic::catch_unwind(move || {
-//         let filter = |c: &mut Check| {
-//             if c.index == 2 {
-//                 panic!("panic at index: {}", c.index);
-//             }
-//             // Verify that if the filter could panic again on another element
-//             // that it would not cause a double panic and all elements of the
-//             // vec would still be dropped exactly once.
-//             if c.index == 4 {
-//                 panic!("panic at index: {}", c.index);
-//             }
-//             c.index < 6
-//         };
-//         let drain = data.drain_filter(filter);
+    let _ = std::panic::catch_unwind(move || {
+        let filter = |c: &mut Check| {
+            if c.index == 2 {
+                panic!("panic at index: {}", c.index);
+            }
+            // Verify that if the filter could panic again on another element
+            // that it would not cause a double panic and all elements of the
+            // vec would still be dropped exactly once.
+            if c.index == 4 {
+                panic!("panic at index: {}", c.index);
+            }
+            c.index < 6
+        };
+        let drain = data.drain_filter(filter);
 
-//         // NOTE: The DrainFilter is explicitly consumed
-//         drain.for_each(drop);
-//     });
+        // NOTE: The DrainFilter is explicitly consumed
+        drain.for_each(drop);
+    });
 
-//     let drop_counts = drop_counts.lock().unwrap();
-//     assert_eq!(check_count, drop_counts.len());
+    let drop_counts = drop_counts.lock().unwrap();
+    assert_eq!(check_count, drop_counts.len());
 
-//     for (index, count) in drop_counts.iter().cloned().enumerate() {
-//         assert_eq!(1, count, "unexpected drop count at index: {} (count: {})", index, count);
-//     }
-// }
+    for (index, count) in drop_counts.iter().cloned().enumerate() {
+        assert_eq!(
+            1, count,
+            "unexpected drop count at index: {} (count: {})",
+            index, count
+        );
+    }
+}
 
-// // FIXME: Re-enable emscripten once it can catch panics
-// #[test]
-// #[cfg(not(target_os = "emscripten"))]
-// fn drain_filter_unconsumed_panic() {
-//     use std::rc::Rc;
-//     use std::sync::Mutex;
+// FIXME: Re-enable emscripten once it can catch panics
+#[test]
+#[cfg(not(target_os = "emscripten"))]
+fn drain_filter_unconsumed_panic() {
+    use std::rc::Rc;
+    use std::sync::Mutex;
 
-//     struct Check {
-//         index: usize,
-//         drop_counts: Rc<Mutex<Vec<usize>>>,
-//     };
+    struct Check {
+        index: usize,
+        drop_counts: Rc<Mutex<MiniVec<usize>>>,
+    };
 
-//     impl Drop for Check {
-//         fn drop(&mut self) {
-//             self.drop_counts.lock().unwrap()[self.index] += 1;
-//             println!("drop: {}", self.index);
-//         }
-//     }
+    impl Drop for Check {
+        fn drop(&mut self) {
+            self.drop_counts.lock().unwrap()[self.index] += 1;
+            println!("drop: {}", self.index);
+        }
+    }
 
-//     let check_count = 10;
-//     let drop_counts = Rc::new(Mutex::new(vec![0_usize; check_count]));
-//     let mut data: Vec<Check> = (0..check_count)
-//         .map(|index| Check { index, drop_counts: Rc::clone(&drop_counts) })
-//         .collect();
+    let check_count = 10;
+    let drop_counts = Rc::new(Mutex::new(mini_vec![0_usize; check_count]));
+    let mut data: MiniVec<Check> = (0..check_count)
+        .map(|index| Check {
+            index,
+            drop_counts: Rc::clone(&drop_counts),
+        })
+        .collect();
 
-//     let _ = std::panic::catch_unwind(move || {
-//         let filter = |c: &mut Check| {
-//             if c.index == 2 {
-//                 panic!("panic at index: {}", c.index);
-//             }
-//             // Verify that if the filter could panic again on another element
-//             // that it would not cause a double panic and all elements of the
-//             // vec would still be dropped exactly once.
-//             if c.index == 4 {
-//                 panic!("panic at index: {}", c.index);
-//             }
-//             c.index < 6
-//         };
-//         let _drain = data.drain_filter(filter);
+    let _ = std::panic::catch_unwind(move || {
+        let filter = |c: &mut Check| {
+            if c.index == 2 {
+                panic!("panic at index: {}", c.index);
+            }
+            // Verify that if the filter could panic again on another element
+            // that it would not cause a double panic and all elements of the
+            // vec would still be dropped exactly once.
+            if c.index == 4 {
+                panic!("panic at index: {}", c.index);
+            }
+            c.index < 6
+        };
+        let _drain = data.drain_filter(filter);
 
-//         // NOTE: The DrainFilter is dropped without being consumed
-//     });
+        // NOTE: The DrainFilter is dropped without being consumed
+    });
 
-//     let drop_counts = drop_counts.lock().unwrap();
-//     assert_eq!(check_count, drop_counts.len());
+    let drop_counts = drop_counts.lock().unwrap();
+    assert_eq!(check_count, drop_counts.len());
 
-//     for (index, count) in drop_counts.iter().cloned().enumerate() {
-//         assert_eq!(1, count, "unexpected drop count at index: {} (count: {})", index, count);
-//     }
-// }
+    for (index, count) in drop_counts.iter().cloned().enumerate() {
+        assert_eq!(
+            1, count,
+            "unexpected drop count at index: {} (count: {})",
+            index, count
+        );
+    }
+}
 
-// #[test]
-// fn drain_filter_unconsumed() {
-//     let mut vec = vec![1, 2, 3, 4];
-//     let drain = vec.drain_filter(|&mut x| x % 2 != 0);
-//     drop(drain);
-//     assert_eq!(vec, [2, 4]);
-// }
+#[test]
+fn drain_filter_unconsumed() {
+    let mut vec = mini_vec![1, 2, 3, 4];
+    let drain = vec.drain_filter(|&mut x| x % 2 != 0);
+    drop(drain);
+    assert_eq!(vec, [2, 4]);
+}
 
 #[test]
 fn test_reserve_exact() {

--- a/tests/vec.rs
+++ b/tests/vec.rs
@@ -858,6 +858,11 @@ fn assert_covariance() {
     }
 }
 
+// this test really only works because of the stdlib using trait specialization here
+// someday, we need to improve our FromIterator implementation to check for a TrustedLen iterator
+// which then checks if it can reuse the allocation the MiniVec had previously
+// if we can reuse the allocation then this will wind up passing
+//
 // #[test]
 // fn from_into_inner() {
 //     let vec = vec![1, 2, 3];


### PR DESCRIPTION
Add implementation of `DrainFilter` thus bringing `MiniVec` closer and closer to full `std::vec::Vec` compatibility.

Closes https://github.com/LeonineKing1199/minivec/issues/12