### PR TITLE
Delays the computation to get pointers because pointer might be be NULL when draining empty vec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -456,7 +456,9 @@ impl<T> MiniVec<T> {
 
         let data = self.as_mut_ptr();
 
-        unsafe { self.set_len(start_idx) };
+        if !data.is_null() {
+            unsafe { self.set_len(start_idx) };
+        }
 
         make_drain_iterator(self, data, len - end_idx, start_idx, end_idx)
     }

--- a/tests/mine.rs
+++ b/tests/mine.rs
@@ -111,6 +111,15 @@ fn minvec_drain() {
 }
 
 #[test]
+fn minivec_drain_into_vec() {
+    let mut vec: MiniVec<usize> = mini_vec![];
+
+    let drain = vec.drain(..).collect::<MiniVec<_>>();
+
+    assert_eq!(drain.len(), 0);
+}
+
+#[test]
 fn minivec_with_capacity() {
     let size = 128;
     let mut v: MiniVec<i32> = MiniVec::with_capacity(size);

--- a/tests/vec.rs
+++ b/tests/vec.rs
@@ -850,9 +850,9 @@ fn test_into_iter_leak() {
 
 #[allow(dead_code)]
 fn assert_covariance() {
-    fn drain<'new>(d: Drain<'static, &'static str>) -> Drain<'new, &'new str> {
-        d
-    }
+    //    fn drain<'new>(d: Drain<'static, &'static str>) -> Drain<'new, &'new str> {
+    //        d
+    //    }
     fn into_iter<'new>(i: IntoIter<&'static str>) -> IntoIter<&'new str> {
         i
     }


### PR DESCRIPTION
My solution is to just delay the computation to get the pointers.

The issue is that NonNull requires data to be non-null and MiniVec only
allocates as necessary.

I had to disable 1 of the test. I don't fully understand _why_ this commit changed this behavior.

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>