### PR TITLE
Fix/crashing when draining empty minivec small

### DIFF
--- a/src/impl/drain.rs
+++ b/src/impl/drain.rs
@@ -18,13 +18,24 @@ pub fn make_drain_iterator<'a, T>(
     start_idx: usize,
     end_idx: usize,
 ) -> Drain<'a, T> {
-    Drain {
-        vec_: core::ptr::NonNull::from(vec),
-        drain_pos_: unsafe { core::ptr::NonNull::new_unchecked(data.add(start_idx)) },
-        drain_end_: unsafe { core::ptr::NonNull::new_unchecked(data.add(end_idx)) },
-        remaining_pos_: unsafe { core::ptr::NonNull::new_unchecked(data.add(end_idx)) },
-        remaining_: remaining,
-        marker_: core::marker::PhantomData,
+    if data.is_null() {
+        Drain {
+            vec_: core::ptr::NonNull::from(vec),
+            drain_pos_: core::ptr::NonNull::dangling(),
+            drain_end_: core::ptr::NonNull::dangling(),
+            remaining_pos_: core::ptr::NonNull::dangling(),
+            remaining_: remaining,
+            marker_: core::marker::PhantomData,
+        }
+    } else {
+        Drain {
+            vec_: core::ptr::NonNull::from(vec),
+            drain_pos_: unsafe { core::ptr::NonNull::new_unchecked(data.add(start_idx)) },
+            drain_end_: unsafe { core::ptr::NonNull::new_unchecked(data.add(end_idx)) },
+            remaining_pos_: unsafe { core::ptr::NonNull::new_unchecked(data.add(end_idx)) },
+            remaining_: remaining,
+            marker_: core::marker::PhantomData,
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -456,7 +456,9 @@ impl<T> MiniVec<T> {
 
         let data = self.as_mut_ptr();
 
-        unsafe { self.set_len(start_idx) };
+        if !data.is_null() {
+            unsafe { self.set_len(start_idx) };
+        }
 
         make_drain_iterator(self, data, len - end_idx, start_idx, end_idx)
     }

--- a/tests/mine.rs
+++ b/tests/mine.rs
@@ -98,6 +98,15 @@ fn minivec_dedup_needs_drop() {
 }
 
 #[test]
+fn minivec_drain_into_vec() {
+    let mut vec: MiniVec<usize> = mini_vec![];
+
+    let drain = vec.drain(..).collect::<MiniVec<_>>();
+
+    assert_eq!(drain.len(), 0);
+}
+
+#[test]
 fn minvec_drain() {
     let mut vec = mini_vec![1, 2, 3];
 


### PR DESCRIPTION
This is a much shorter that prevents the crash.
However, I think there's still an underlying problem with using `NonNull` on a `NULL` `data`.