### PR TITLE
Add repr(transparent) to truly match pointer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ use crate::r#impl::splice::make_splice_iterator;
 
 pub use crate::r#impl::{Drain, DrainFilter, IntoIter, Splice};
 
+#[repr(transparent)]
 /// `MiniVec` is a space-optimized implementation of `alloc::vec::Vec` that is only the size of a single pointer and
 /// also extends portions of its API, including support for over-aligned allocations. `MiniVec` also aims to bring as
 /// many Nightly features from `Vec` to stable toolchains as is possible. In many cases, it is a drop-in replacement


### PR DESCRIPTION
Since goal is kinda to match pointer in size, we might as well make it ABI compatible with pointer.

This should enable passing minivec as simple void pointer across C FFI